### PR TITLE
Load textdomain on init

### DIFF
--- a/shipping-workshop.php
+++ b/shipping-workshop.php
@@ -13,6 +13,11 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+function shipping_workshop_load_textdomain() {
+	load_plugin_textdomain( 'shipping-workshop', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'shipping_workshop_load_textdomain' );
+
 // Define SHIPPING_WORKSHOP_VERSION.
 $plugin_data = get_file_data( __FILE__, array( 'version' => 'version' ) );
 define( 'SHIPPING_WORKSHOP_VERSION', $plugin_data['version'] );

--- a/src/js/shipping-workshop-block/edit.js
+++ b/src/js/shipping-workshop-block/edit.js
@@ -34,7 +34,7 @@ export const Edit = ( { attributes, setAttributes } ) => {
 						text ||
 						defaultShippingText ||
 						__(
-							'If I am not at home, please…',
+							'If I am not at home please…',
 							'shipping-workshop'
 						)
 					}


### PR DESCRIPTION
Hi @fabiocorreia95 - this PR makes some changes to enable translations to load, could you give it a try?

## Testing instructions

- Generate the POT file
  - In the `wp-content/plugins` directory run: `wp i18n make-pot ./wceu23-shipping-workshop-final ./wceu23-shipping-workshop-final/languages/shipping-workshop.pot`
- Install something like LocoTranslate and create a new language
- Change some of the plugin's strings and then change the site language.
- Verify the string translations show correctly.

Closes #6